### PR TITLE
Correct bug in DBus method call for DBus based conditions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whenever"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ as the consequence of the verification of a **_condition_**. The concepts of tas
 
 The supported types of [**_condition_**](#conditions) are the following:
 
-* [_Interval_ based](#interval): the _periodic_ conditions are verified after a certain time interval has passed since **whenever** has started, and may be verified again after the same amount of time if the condition is set to be _recurrent_
+* [_Interval_ based](#interval): the _periodic_ conditions are verified after a certain time interval has passed since **whenever** has started, and may be verified again after the same amount of time if the condition is set to be _recurring_
 * [_Time_ based](#time): one or more instants in time can be specified when the condition is verified
 * [_Idle_ user session](#command): this type of condition is verified after the session has been idle for the specified amount of time
 * [_Command_ execution](#command): an available executable (be it a script, a batch file on Windows, a binary) is run, its exit code or output is checked and, when an expected outcome is found, the condition is considered verified - or failed on an explicitly undesired outcome
@@ -469,7 +469,7 @@ The following table illustrates the parameters specific to _command_ based condi
 | Entry                       | Default | Description                                                                                                                  |
 |-----------------------------|:-------:|------------------------------------------------------------------------------------------------------------------------------|
 | `type`                      | N/A     | has to be set to `"interval"` (mandatory)                                                                                    |
-| `check_after`               | (empty) | number of seconds that have to pass before the condition is checked the first time or further times if `recurrent` is _true_ |
+| `check_after`               | (empty) | number of seconds that have to pass before the condition is checked the first time or further times if `recurring` is _true_ |
 | `startup_path`              | N/A     | the directory in which the command is started (mandatory)                                                                    |
 | `command`                   | N/A     | path to the executable (mandatory; if the path is omitted, the executable should be found in the search _PATH_)              |
 | `command_arguments`         | N/A     | arguments to pass to the executable: can be an empty list, `[]` (mandatory)                                                  |
@@ -528,7 +528,7 @@ The specific parameters are described in the following table:
 | Entry              | Default | Description                                                                                                                  |
 |--------------------|:-------:|------------------------------------------------------------------------------------------------------------------------------|
 | `type`             | N/A     | has to be set to `"lua"` (mandatory)                                                                                         |
-| `check_after`      | (empty) | number of seconds that have to pass before the condition is checked the first time or further times if `recurrent` is _true_ |
+| `check_after`      | (empty) | number of seconds that have to pass before the condition is checked the first time or further times if `recurring` is _true_ |
 | `script`           | N/A     | the _Lua_ code that has to be executed by the internal interpreter (mandatory)                                               |
 | `expect_all`       | _false_ | if _true_, all the expected results have to be matched to consider the task successful, otherwise at least one               |
 | `expected_results` | `{}`    | a dictionary of variable names and their expected values to be checked after execution                                       |
@@ -635,9 +635,9 @@ The specific parameters are described in the following table:
 | Entry                 | Default | Description                                                                                                                  |
 |-----------------------|:-------:|------------------------------------------------------------------------------------------------------------------------------|
 | `type`                | N/A     | has to be set to `"dbus"` (mandatory)                                                                                        |
-| `check_after`         | (empty) | number of seconds that have to pass before the condition is checked the first time or further times if `recurrent` is _true_ |
+| `check_after`         | (empty) | number of seconds that have to pass before the condition is checked the first time or further times if `recurring` is _true_ |
 | `bus`                 | N/A     | the bus on which the method is invoked: must be either `":system"` or `":session"`, including the starting colon (mandatory) |
-| `service`             | N/A     | the name of the _service_ that exposes the required _object_ and the _interface_ to invoke query (mandatory)                 |
+| `service`             | N/A     | the name of the _service_ that exposes the required _object_ and the _interface_ to invoke or query (mandatory)              |
 | `object_path`         | N/A     | the _object_ exposing the _interface_ to invoke or query (mandatory)                                                         |
 | `interface`           | N/A     | the _interface_ to invoke or query (mandatory)                                                                               |
 | `method`              | N/A     | the name of the _method_ to be invoked (mandatory)                                                                           |
@@ -772,7 +772,7 @@ and the details of the configuration entries are described in the table below:
 | `condition`           | N/A     | the name of the associated _event_ based condition (mandatory)                                                              |
 | `bus`                 | N/A     | the bus on which to listen for events: must be either `":system"` or `":session"`, including the starting colon (mandatory) |
 | `parameter_check_all` | _false_ | if _true_, all the returned parameters will have to match the criteria for verification, otherwise one match is sufficient  |
-| `parameter_check`     | (empty) | a list of maps consisting of three fields each, each of which is a check to be be performed on return parameters            |
+| `parameter_check`     | (empty) | a list of maps consisting of three fields each, each of which is a check to be performed on return parameters               |
 
 The consideration about indexes in return parameters are the same that have been seen for [_DBus message_ based conditions](#dbus-method).
 

--- a/src/condition/dbus_cond.rs
+++ b/src/condition/dbus_cond.rs
@@ -1304,28 +1304,26 @@ impl Condition for DbusMethodCondition {
         // the `call_method` function
         let message;
         if let Some(params) = self.param_call.clone() {
-            let a;
             let mut arg = zvariant::StructureBuilder::new();
             for p in params {
                 let v = zvariant::Value::from(p);
                 arg.push_value(v);
             }
-            a = arg.build();
             message = task::block_on(async {
                 conn.call_method(
-                    Some(service.as_str()),
+                    if service.is_empty() { None } else { Some(service.as_str()) },
                     object_path.as_str(),
-                    Some(interface.as_str()),
+                    if interface.is_empty() { None } else { Some(interface.as_str()) },
                     method.as_str(),
-                    &a,
+                    &arg.build(),
                 ).await
             });
         } else {
             message = task::block_on(async {
                 conn.call_method(
-                    Some(service.as_str()),
+                    if service.is_empty() { None } else { Some(service.as_str()) },
                     object_path.as_str(),
-                    Some(interface.as_str()),
+                    if interface.is_empty() { None } else { Some(interface.as_str()) },
                     method.as_str(),
                     &(),
                 ).await

--- a/src/condition/dbus_cond.rs
+++ b/src/condition/dbus_cond.rs
@@ -991,10 +991,10 @@ impl DbusMethodCondition {
                 param_checks.push(ParameterCheckTest { index: index_list, operator, value });
             }
             // finally the parameter checks become `Some` and makes its way
-            // into the new event structure: the list is formally correct, but
-            // it may not be compatible with the returned parameters, in which
-            // case the parameter check will evaluate to _non-verified_ and a
-            // warning log message will be issued (see below)
+            // into the new condition structure: the list is formally correct,
+            // but it may not be compatible with the returned parameters, in
+            // which case the parameter check will evaluate to _non-verified_
+            // and a warning log message will be issued (see below)
             new_condition.param_checks = Some(param_checks);
 
             // `parameter_check_all` only makes sense if the paramenter check
@@ -1219,7 +1219,7 @@ impl Condition for DbusMethodCondition {
         }
 
         // panic here if the bus name is incorrect: should have been fixed
-        // when the event was configured and constructed
+        // when the condition was configured and constructed
         async fn _get_connection(bus: &str) -> zbus::Result<zbus::Connection> {
             let connection;
             if bus == ":session" {
@@ -1227,7 +1227,7 @@ impl Condition for DbusMethodCondition {
             } else if bus == ":system" {
                 connection = zbus::Connection::system().await;
             } else {
-                panic!("specified bus `{bus}` not supported for event");
+                panic!("specified bus `{bus}` not supported for DBus method based condition");
             }
             connection
         }
@@ -1296,24 +1296,41 @@ impl Condition for DbusMethodCondition {
         }
         let conn = conn.unwrap();
 
-        let mut arg = zvariant::StructureBuilder::new();
+        // the following bifurcation is in my opinion quite ugly, however it
+        // looks like the entire `zbus` crate is built with the purpose of
+        // providing a way to proxy known existing DBus methods at compile
+        // time, and thus I did not found a way to call a method without
+        // arguments if not by passing a pointer to the unit as argument to
+        // the `call_method` function
+        let message;
         if let Some(params) = self.param_call.clone() {
+            let a;
+            let mut arg = zvariant::StructureBuilder::new();
             for p in params {
                 let v = zvariant::Value::from(p);
                 arg.push_value(v);
             }
+            a = arg.build();
+            message = task::block_on(async {
+                conn.call_method(
+                    Some(service.as_str()),
+                    object_path.as_str(),
+                    Some(interface.as_str()),
+                    method.as_str(),
+                    &a,
+                ).await
+            });
+        } else {
+            message = task::block_on(async {
+                conn.call_method(
+                    Some(service.as_str()),
+                    object_path.as_str(),
+                    Some(interface.as_str()),
+                    method.as_str(),
+                    &(),
+                ).await
+            });
         }
-        let a = arg.build();
-        let message = task::block_on(async {
-            conn.call_method(
-                Some(service.as_str()),
-                object_path.as_str(),
-                Some(interface.as_str()),
-                method.as_str(),
-                &a,
-            ).await
-            // proxy.call_method(method.as_str(), &self.param_call.as_ref().unwrap()).await
-        });
         if let Err(e) = message {
             self.log(
                 LogType::Warn,


### PR DESCRIPTION
Fixes #7: The bug reported in the issue, in which an argument was actually passed to a DBus method call even in the case of argument-less methods, and which prevented the method to be correctly invoked when no arguments were provided, is adressed in this branch. The resulting code has been tested on Debian 12 with methods both accepting arguments and not.