### PR TITLE
Remove variable references from calls to expect()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whenever"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 edition = "2021"
 

--- a/src/condition/registry.rs
+++ b/src/condition/registry.rs
@@ -97,7 +97,7 @@ impl ConditionRegistry {
                 Some(r
                     .clone()
                     .lock()
-                    .expect(&format!("cannot lock condition {name} to retrieve type"))
+                    .expect("cannot lock condition to retrieve type")
                     .get_type()
                     .to_string()
                 )
@@ -184,11 +184,11 @@ impl ConditionRegistry {
                 .expect("cannot lock condition registry")
                 .remove(name) {
                 let Ok(mx) = Arc::try_unwrap(r) else {
-                    panic!("attempt to extract referenced condition {name}")
+                    panic!("cannot extract referenced condition {name}")
                 };
                 let mut condition = mx
                     .into_inner()
-                    .expect(&format!("attempt to extract locked condition {name}"));    // <- may have to fix this
+                    .expect("cannot extract locked condition");    // <- may have to fix this
                 condition.set_id(0);
                 Ok(Some(condition))
             } else {
@@ -241,13 +241,13 @@ impl ConditionRegistry {
                 let clist = self.condition_list.clone();
                 let mut guard = clist.lock().expect("cannot lock condition registry");
                 cond = guard.get_mut(name)
-                    .expect(&format!("cannot retrieve condition {name} for reset"))
+                    .expect("cannot retrieve condition for reset")
                     .clone();
             }
 
             // when we acquire the lock, we can safely reset the condition right
             // here and return the operation result from the condition itself
-            cond.clone().lock().expect(&format!("condition {name} cannot be locked")).reset()
+            cond.clone().lock().expect("condition cannot be locked").reset()
         }
     }
 
@@ -292,13 +292,13 @@ impl ConditionRegistry {
                 let clist = self.condition_list.clone();
                 let mut guard = clist.lock().expect("cannot lock condition registry");
                 cond = guard.get_mut(name)
-                    .expect(&format!("cannot retrieve condition {name} for reset"))
+                    .expect("cannot retrieve condition for reset")
                     .clone();
             }
 
             // when we acquire the lock, we can safely reset the condition right
             // here and return the operation result from the condition itself
-            cond.clone().lock().expect(&format!("condition {name} cannot be locked")).suspend()
+            cond.clone().lock().expect("condition cannot be locked").suspend()
         }
     }
 
@@ -350,13 +350,13 @@ impl ConditionRegistry {
                 let clist = self.condition_list.clone();
                 let mut guard = clist.lock().expect("cannot lock condition registry");
                 cond = guard.get_mut(name)
-                    .expect(&format!("cannot retrieve condition {name} for reset"))
+                    .expect("cannot retrieve condition for reset")
                     .clone();
             }
 
             // when we acquire the lock, we can safely reset the condition right
             // here and return the operation result from the condition itself
-            cond.clone().lock().expect(&format!("condition {name} cannot be locked")).resume()
+            cond.clone().lock().expect("condition cannot be locked").resume()
         }
     }
 
@@ -393,10 +393,10 @@ impl ConditionRegistry {
         }
         let cond = guard
             .get(name)
-            .expect(&format!("cannot retrieve condition {name}"))
+            .expect("cannot retrieve condition")
             .clone();
         drop(guard);
-        let id = cond.lock().expect(&format!("cannot lock condition {name}")).get_id();
+        let id = cond.lock().expect("cannot lock condition").get_id();
         Some(id)
     }
 
@@ -433,7 +433,7 @@ impl ConditionRegistry {
             let clist = self.condition_list.clone();
             let mut guard = clist.lock().expect("cannot lock condition registry");
             cond = guard.get_mut(name)
-                .expect(&format!("cannot retrieve condition {name} for busy check"))
+                .expect("cannot retrieve condition for busy check")
                 .clone();
         }
 
@@ -518,7 +518,7 @@ impl ConditionRegistry {
             let clist = self.condition_list.clone();
             let mut guard = clist.lock().expect("cannot lock condition registry");
             cond = guard.get_mut(name)
-                .expect(&format!("cannot retrieve condition {name} for testing"))
+                .expect("cannot retrieve condition for testing")
                 .clone();
         }
 

--- a/src/event/registry.rs
+++ b/src/event/registry.rs
@@ -150,11 +150,11 @@ impl EventRegistry {
                 .expect("cannot lock event registry")
                 .remove(name) {
                 let Ok(mx) = Arc::try_unwrap(r) else {
-                    panic!("attempt to extract referenced event {name}")
+                    panic!("cannot extract referenced event {name}")
                 };
                 let mut event = mx
                     .into_inner()
-                    .expect(&format!("attempt to extract locked event {name}"));    // <- may have to fix this
+                    .expect("cannot extract locked event");
                 event.set_id(0);
                 Ok(Some(event))
             } else {
@@ -205,10 +205,10 @@ impl EventRegistry {
         }
         let event = guard
             .get(name)
-            .expect(&format!("cannot retrieve event {name}"))
+            .expect("cannot retrieve event")
             .clone();
         drop(guard);
-        let id = event.lock().expect(&format!("cannot lock event {name}")).get_id();
+        let id = event.lock().expect("cannot lock event").get_id();
         Some(id)
     }
 
@@ -233,11 +233,11 @@ impl EventRegistry {
             let elist = self.event_list.clone();
             let guard = elist.lock().expect("cannot lock event registry");
             event = guard.get(name)
-                .expect(&format!("cannot retrieve event {name} for activation"))
+                .expect("cannot retrieve event for activation")
                 .clone();
         }
 
-        let mxevent = event.lock().expect(&format!("cannot lock event {name} for activation"));
+        let mxevent = event.lock().expect("cannot lock event for activation");
         let name_copy = String::from(name);
         let event_name = Arc::new(Mutex::new(name_copy));
         if mxevent.requires_thread() {
@@ -344,12 +344,12 @@ impl EventRegistry {
             let elist = self.event_list.clone();
             let guard = elist.lock().expect("cannot lock event registry");
             event = guard.get(name)
-                .expect(&format!("cannot retrieve event {name} for activation"))
+                .expect("cannot retrieve event for activation")
                 .clone();
         }
 
         let mxevent = event.lock()
-            .expect(&format!("cannot lock event {name} for activation"));
+            .expect("cannot lock event for activation");
         if let Ok(res) = mxevent.fire_condition() {
             if res {
                 log(

--- a/src/task/registry.rs
+++ b/src/task/registry.rs
@@ -176,7 +176,7 @@ impl TaskRegistry {
                 };
                 let mut task = mx
                     .into_inner()
-                    .expect(&format!("attempt to extract locked task {name}"));
+                    .expect("cannot extract locked task");
                 task.set_id(0);
                 Ok(Some(task))
             } else {
@@ -223,10 +223,10 @@ impl TaskRegistry {
         }
         let task = guard
             .get(name)
-            .expect(&format!("cannot retrieve task {name}"))
+            .expect("cannot retrieve task")
             .clone();
         drop(guard);
-        let id = task.lock().expect(&format!("cannot lock task {name}")).get_id();
+        let id = task.lock().expect("cannot lock task").get_id();
         Some(id)
     }
 
@@ -274,7 +274,7 @@ impl TaskRegistry {
         let mut res: HashMap<String, Result<Option<bool>, std::io::Error>> = HashMap::new();
 
         if !self.has_all_tasks(names) {
-            panic!("(trigger: {trigger_name}) run_tasks_seq task(s) not found in registry")
+            panic!("(trigger {trigger_name}): run_tasks_seq task(s) not found in registry")
         }
 
         // although this function runs a task sequentially, we must handle the
@@ -290,13 +290,13 @@ impl TaskRegistry {
                 .expect("cannot lock task registry");
             task = guard
                 .get_mut(*name)
-                .expect(&format!("cannot retrieve task {name} for running"))
+                .expect("cannot retrieve task for running")
                 .clone();
             drop(guard);
             let cur_res;
             let mut guard = task
                 .lock()
-                .expect(&format!("cannot lock task {name} while extracting"));
+                .expect("cannot lock task while extracting");
             cur_res = guard.run(trigger_name);
             log(
                 LogType::Trace,
@@ -425,14 +425,14 @@ impl TaskRegistry {
                 .expect("cannot lock task registry");
             task = guard
                 .get_mut(&aname.clone().to_string())
-                .expect(&format!("cannot retrieve task {name} for running"))
+                .expect("cannot retrieve task for running")
                 .clone();
             drop(guard);
 
             let handle = spawn(move || {
                 let outcome = task
                     .lock()
-                    .expect(&format!("cannot lock task {aname} for running"))
+                    .expect("cannot lock task for running")
                     .run(&atrname);
                 atx.lock().unwrap().send((aname.clone(), outcome)).unwrap();
             });


### PR DESCRIPTION
Remove references to local variables in calls to the `expect()` unwrapper: this should avoid the possibility of panicking within a panic condition. Context-explaining variables have been kept in direct calls to the `panic!` macro, though:the maco itself is designed to provide refernces to the context, and all used variables in such calls are actually expendable references to strings. Fixes #11.