### PR TITLE
Do not sync reads to LOGGER_EMITS_JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whenever"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 edition = "2021"
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -45,7 +45,7 @@
 //! utility the state of the scheduler, and possibily give the opportunity to
 //! organize communication to the user in a friendlier way.
 
-use std::sync::Mutex;
+use std::sync::RwLock;
 use lazy_static::lazy_static;
 
 
@@ -54,7 +54,7 @@ use lazy_static::lazy_static;
 // the common logging function should know whether the logger is initialized
 // to return JSON message and build the JSON payload itself
 lazy_static! {
-    static ref LOGGER_EMITS_JSON: Mutex<bool> = Mutex::new(false);
+    static ref LOGGER_EMITS_JSON: RwLock<bool> = RwLock::new(false);
 }
 
 
@@ -180,7 +180,7 @@ pub mod logging {
                         } else if logplain {
                             log_format_plain
                         } else if logjson {
-                            *LOGGER_EMITS_JSON.lock().unwrap() = true;
+                            *LOGGER_EMITS_JSON.write().unwrap() = true;
                             log_format_json
                         } else {
                             log_format_plain
@@ -214,7 +214,7 @@ pub mod logging {
                         } else if logplain {
                             log_format_plain
                         } else if logjson {
-                            *LOGGER_EMITS_JSON.lock().unwrap() = true;
+                            *LOGGER_EMITS_JSON.write().unwrap() = true;
                             log_format_json
                         } else {
                             log_format_colors
@@ -269,7 +269,7 @@ pub mod logging {
         message: &str,
     ) {
         let payload;
-        if *LOGGER_EMITS_JSON.lock().unwrap() {
+        if *LOGGER_EMITS_JSON.read().unwrap() {
             let context = if let Some((item, item_id)) = item {
                 json!({
                     "emitter": emitter,


### PR DESCRIPTION
Use `RwLock` instead of `Mutex` as pointer to the shared flag `LOGGER_EMITS_JSON` in the logging module. This should avoid possible locks while waiting to access the logging facility due to reading the flag itself, which would be useless as the logger is already _per se_ synchronized. Closes #14.