### PR TITLE
Specify user name in instance ID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whenever"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 edition = "2021"
 
@@ -28,6 +28,7 @@ single-instance = "0.3.3"
 notify = "6.0.0"
 async-std = "1.12.0"
 zbus = "3.13.1"
+whoami = "1.4.1"
 
 # user-idle has a problem on wayland-based sessions: work around by using
 # user-idle = { version = "0.5.3", default-features = false, features = ["dbus"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use lazy_static::lazy_static;
 use clokwerk::{Scheduler, TimeUnits};
 use cfgmap::{CfgValue, CfgMap};
 use rand::{thread_rng, RngCore};
+use whoami::username;
 use single_instance::SingleInstance;
 
 // the modules defined and used in this application
@@ -56,7 +57,7 @@ lazy_static! {
     static ref EXECUTION_BUCKET: ExecutionBucket = ExecutionBucket::new();
 
     // single instance name
-    static ref INSTANCE_GUID: String = format!("{APP_NAME}-663f98a9-a1ef-46ef-a7bc-bb2482f42440");
+    static ref INSTANCE_GUID: String = format!("{APP_NAME}-{}-663f98a9-a1ef-46ef-a7bc-bb2482f42440", username());
 
     // set this if the application must exit
     static ref APPLICATION_MUST_EXIT: Mutex<bool> = Mutex::new(false);


### PR DESCRIPTION
Include username in the single-instance identifying string, so that only a single instance is allowed, but on a per-user basis. Closes #17.