### PR TITLE
Registry sync policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whenever"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 edition = "2021"
 

--- a/src/condition/registry.rs
+++ b/src/condition/registry.rs
@@ -2,7 +2,7 @@
 //!
 //! `condition::registry` implements the main registry for `Condition` objects.
 //!
-//! Implements the task registry as the main interface to access and check
+//! Implements the condition registry as the main interface to access and check
 //! _active_ conditions: a `Condition` object cannot in fact be considered
 //! active until it is _registered_. A registered condition has an unique
 //! nonzero ID.
@@ -25,7 +25,7 @@ use crate::constants::*;
 
 // module-wide values
 lazy_static! {
-    // the main task ID generator
+    // the main condition ID generator
     static ref UID_GENERATOR: SequenceGenerator = {
         let mut _uidgen = SequenceGenerator;
         _uidgen

--- a/src/event/registry.rs
+++ b/src/event/registry.rs
@@ -26,14 +26,14 @@ use crate::constants::*;
 
 // module-wide values
 lazy_static! {
-    // the main task ID generator
+    // the main event ID generator
     static ref UID_GENERATOR: SequenceGenerator = {
         let mut _uidgen = SequenceGenerator;
         _uidgen
     };
 }
 
-// the specific task ID generator: used internally to register an event
+// the specific event ID generator: used internally to register an event
 #[allow(dead_code)]
 fn generate_event_id() -> i64 {
     UID_GENERATOR.next_id()


### PR DESCRIPTION
The new registry synchronization policy avoids unnecessary locks during execution, as per #19.