### PR TITLE
Support `tags` entry in item configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whenever"
-version = "0.1.19"
+version = "0.1.20"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ _Tasks_ are handled first in this document, because _conditions_ must mandatoril
 
 Tasks are defined via a dedicated table, which means that every task definition must start with the TOML `[[task]]` section header.
 
-Task names are mandatory, and must be provided as alphanumeric strings (may include underscores), beginning with a letter. The task type must be either `"command"` or `"lua"` according to what is configured, any other value is considered a configuration error.
+Task names are mandatory, and must be provided as alphanumeric strings (may include underscores), beginning with a letter. The task type must be either `"command"` or `"lua"` according to what is configured, any other value is considered a configuration error. There is another optional entry, namely `tags`, that is accepted in item configuration: this entry is ignored by **whenever** itself, however it is checked for correctness at startup and the configuration is refused if not set to an array (of strings).
 
 #### Command tasks
 
@@ -285,6 +285,8 @@ The `type` entry can be one of: `"interval"`, `"time"`, `"idle"`, `"command"`, `
 For conditions that should be periodically checked and whose associated task list has to be run _whenever_ they occur (and not just after the first occurrence), the `recurring` entry can be set to _true_. Conditions with no associated tasks (eg. when the user comments out all the associated tasks in the configuration file) are not checked.
 
 The `suspended` entry can assume a _true_ value for conditions for which the user does not want to remove the configuration but should be (at least temporarily) prevented. However, a condition that is suspended by configuration can be awakened using an interactive command (usually by a wrapper): [input commands](#input-commands) passed via the _stdin_ based interface can be used to suspend and resume condition checks when the scheduler is running.
+
+There is another optional entry, namely `tags`, that is accepted in item configuration: this entry is ignored by **whenever** itself, however it is checked for correctness at startup and the configuration is refused if not set to an array (of strings).
 
 Another entry is common to several condition types, that is `check_after`: it can be set to the number of seconds that **whenever** has to wait after startup (and after the last check for _recurring_ conditions) for a subsequent check: this is useful for conditions that can run on a more relaxed schedule, or whose check process has a significant cost in terms of resources, or whose associated task sequence might take a long time to finish. Simpler conditions and conditions based on time do not accept this entry.
 
@@ -698,6 +700,8 @@ One notable exception, which is also particularly useful, is the _notification_ 
 Note that if an event arises more that once within the tick interval, it is automatically _debounced_ and a single occurrence is counted.
 
 All _event_ definition sections must start with the TOML `[[event]]` header.
+
+An optional entry, namely `tags`, is accepted in item configuration: this entry is ignored by **whenever** itself, however it is checked for correctness at startup and the configuration is refused if not set to an array (of strings).
 
 The associated conditions must exist, otherwise an error is raised and **whenever** aborts.
 

--- a/src/condition/bucket_cond.rs
+++ b/src/condition/bucket_cond.rs
@@ -231,6 +231,7 @@ impl BucketCondition {
         let check = [
             "type",
             "name",
+            "tags",
             "tasks",
             "recurring",
             "execute_sequence",
@@ -308,6 +309,16 @@ impl BucketCondition {
         new_condition.suspended = false;
 
         // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
         let cur_key = "tasks";
         if let Some(item) = cfgmap.get(cur_key) {
             if !item.is_list() {

--- a/src/condition/command_cond.rs
+++ b/src/condition/command_cond.rs
@@ -406,6 +406,7 @@ impl CommandCondition {
         let check = [
             "type",
             "name",
+            "tags",
             "command",
             "command_arguments",
             "startup_path",
@@ -560,6 +561,16 @@ impl CommandCondition {
         new_condition.suspended = false;
 
         // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
         let cur_key = "tasks";
         if let Some(item) = cfgmap.get(cur_key) {
             if !item.is_list() {

--- a/src/condition/dbus_cond.rs
+++ b/src/condition/dbus_cond.rs
@@ -708,6 +708,7 @@ impl DbusMethodCondition {
         let check = [
             "type",
             "name",
+            "tags",
             "interval_seconds",
             "tasks",
             "recurring",
@@ -904,6 +905,16 @@ impl DbusMethodCondition {
         new_condition.suspended = false;
 
         // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
         let cur_key = "tasks";
         if let Some(item) = cfgmap.get(cur_key) {
             if !item.is_list() {

--- a/src/condition/idle_cond.rs
+++ b/src/condition/idle_cond.rs
@@ -162,6 +162,7 @@ impl IdleCondition {
         let check = [
             "type",
             "name",
+            "tags",
             "idle_seconds",
             "tasks",
             "recurring",
@@ -261,6 +262,16 @@ impl IdleCondition {
         new_condition.suspended = false;
 
         // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
         let cur_key = "tasks";
         if let Some(item) = cfgmap.get(cur_key) {
             if !item.is_list() {

--- a/src/condition/interval_cond.rs
+++ b/src/condition/interval_cond.rs
@@ -162,6 +162,7 @@ impl IntervalCondition {
         let check = [
             "type",
             "name",
+            "tags",
             "interval_seconds",
             "tasks",
             "recurring",
@@ -261,6 +262,16 @@ impl IntervalCondition {
         new_condition.suspended = false;
 
         // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
         let cur_key = "tasks";
         if let Some(item) = cfgmap.get(cur_key) {
             if !item.is_list() {

--- a/src/condition/lua_cond.rs
+++ b/src/condition/lua_cond.rs
@@ -263,6 +263,7 @@ impl LuaCondition {
         let check = [
             "type",
             "name",
+            "tags",
             "script",
             "tasks",
             "recurring",
@@ -356,6 +357,16 @@ impl LuaCondition {
         new_condition.suspended = false;
 
         // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
         let cur_key = "tasks";
         if let Some(item) = cfgmap.get(cur_key) {
             if !item.is_list() {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,7 +12,8 @@ use std::time::Duration;
 
 
 /// The application name
-pub const APP_NAME: &str = "whenever";
+pub const APP_NAME: &str = env!("CARGO_PKG_NAME");
+pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 
 #[allow(dead_code)]
@@ -121,6 +122,7 @@ pub const LOG_ACTION_CONDITION_BUSY: &str = "condition_busy";
 pub const LOG_ACTION_CONDITION_STATE: &str = "condition_state";
 pub const LOG_ACTION_RUN_COMMAND: &str = "command";
 pub const LOG_ACTION_MAIN_LISTENER: &str = "listener";
+pub const LOG_ACTION_MAIN_START: &str = "starting";
 pub const LOG_ACTION_MAIN_EXIT: &str = "exit";
 
 // other string pub constants

--- a/src/event/dbus_event.rs
+++ b/src/event/dbus_event.rs
@@ -433,6 +433,7 @@ impl DbusMessageEvent {
         let check = [
             "type",
             "name",
+            "tags",
             "condition",
             "bus",
             "rule",
@@ -547,6 +548,16 @@ impl DbusMessageEvent {
         new_event.match_rule = Some(rule);
 
         // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
         let cur_key = "condition";
         let condition;
         if let Some(item) = cfgmap.get(cur_key) {

--- a/src/event/fschange_event.rs
+++ b/src/event/fschange_event.rs
@@ -171,6 +171,7 @@ impl FilesystemChangeEvent {
         let check = [
             "type",
             "name",
+            "tags",
             "condition",
             "watch",
             "recursive",
@@ -241,6 +242,16 @@ impl FilesystemChangeEvent {
         new_event.condition_bucket = Some(bucket);
 
         // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
         let cur_key = "condition";
         let condition;
         if let Some(item) = cfgmap.get(cur_key) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1146,6 +1146,17 @@ fn main() {
         *APPLICATION_MUST_EXIT.lock().unwrap() = true;
     }));
 
+    // write a banner to the log file, stating app name and version
+    log(
+        LogType::Info,
+        LOG_EMITTER_MAIN,
+        LOG_ACTION_MAIN_START,
+        None,
+        LOG_WHEN_START,
+        LOG_STATUS_MSG,
+        &format!("application {APP_NAME} version {APP_VERSION} starting"),
+    );
+
     // read configuration, then in turn:
     //
     // 1. extract the global variables

--- a/src/task/command_task.rs
+++ b/src/task/command_task.rs
@@ -357,6 +357,7 @@ impl CommandTask {
         let check = [
             "type",
             "name",
+            "tags",
             "command",
             "command_arguments",
             "startup_path",
@@ -495,7 +496,15 @@ impl CommandTask {
         );
 
         // common optional parameter initialization
-        // (none here)
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
 
         // specific optional parameter initialization
         let cur_key = "match_exact";

--- a/src/task/lua_task.rs
+++ b/src/task/lua_task.rs
@@ -209,6 +209,7 @@ impl LuaTask {
         let check = [
             "type",
             "name",
+            "tags",
             "script",
             "expect_all",
             "expected_results",
@@ -288,7 +289,15 @@ impl LuaTask {
         );
 
         // common optional parameter initialization
-        // (none here)
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
 
         // specific optional parameter initialization
         let cur_key = "expect_all";


### PR DESCRIPTION
Add support for the (ignored) `tags` entry in item configuration sections and check for correctness of the entry, being an array; also, write a banner with application name and version at the beginning of the log. Closes #21.