### PR TITLE
Maps in `tags` entries and `trigger` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "whenever"
-version = "0.1.20"
+description = "Lightweight task scheduler and automation tool"
+readme = "README.md"
+license = "LGPL-2.1-or-later"
+version = "0.1.21"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
+repository = "https://github.com/almostearthling/whenever/"
 edition = "2021"
 
 [dependencies]

--- a/src/condition/bucket_cond.rs
+++ b/src/condition/bucket_cond.rs
@@ -311,7 +311,7 @@ impl BucketCondition {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,

--- a/src/condition/command_cond.rs
+++ b/src/condition/command_cond.rs
@@ -563,7 +563,7 @@ impl CommandCondition {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,

--- a/src/condition/dbus_cond.rs
+++ b/src/condition/dbus_cond.rs
@@ -907,7 +907,7 @@ impl DbusMethodCondition {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,

--- a/src/condition/idle_cond.rs
+++ b/src/condition/idle_cond.rs
@@ -264,7 +264,7 @@ impl IdleCondition {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,

--- a/src/condition/interval_cond.rs
+++ b/src/condition/interval_cond.rs
@@ -264,7 +264,7 @@ impl IntervalCondition {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,

--- a/src/condition/lua_cond.rs
+++ b/src/condition/lua_cond.rs
@@ -359,7 +359,7 @@ impl LuaCondition {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,

--- a/src/condition/time_cond.rs
+++ b/src/condition/time_cond.rs
@@ -347,6 +347,7 @@ impl TimeCondition {
         let check = [
             "type",
             "name",
+            "tags",
             "time_specifications",
             "tasks",
             "recurring",
@@ -422,6 +423,16 @@ impl TimeCondition {
         new_condition.suspended = false;
 
         // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() && !item.is_map() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
         let cur_key = "tasks";
         if let Some(item) = cfgmap.get(cur_key) {
             if !item.is_list() {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -132,6 +132,13 @@ pub const LOG_ACTION_MAIN_EXIT: &str = "exit";
 // other string pub constants
 pub const STR_UNKNOWN_VALUE: &str = "<unknown>";
 
+// default values
+pub const DEFAULT_SCHEDULER_TICK_SECONDS: i64 = 5;
+pub const DEFAULT_RANDOMIZE_CHECKS_WITHIN_TICKS: bool = false;
+
+// operational values
+pub const MAIN_STDIN_READ_WAIT_MILLISECONDS: u64 = 100;
+
 
 // crate-wide values
 lazy_static! {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -112,6 +112,9 @@ pub const LOG_EMITTER_CONDITION_LUA: &str = "LUA_CONDITION";
 
 pub const LOG_ACTION_NEW: &str = "new";
 pub const LOG_ACTION_TICK: &str = "tick";
+pub const LOG_ACTION_FIRE: &str = "fire";
+pub const LOG_ACTION_TRIGGER: &str = "trigger";
+pub const LOG_ACTION_INSTALL: &str = "install";
 pub const LOG_ACTION_ACTIVE: &str = "active";
 pub const LOG_ACTION_LUA: &str = "exec_lua";
 pub const LOG_ACTION_SCHEDULER_TICK: &str = "scheduler_tick";
@@ -120,6 +123,7 @@ pub const LOG_ACTION_SUSPEND_CONDITION: &str = "suspend_condition";
 pub const LOG_ACTION_RESUME_CONDITION: &str = "resume_condition";
 pub const LOG_ACTION_CONDITION_BUSY: &str = "condition_busy";
 pub const LOG_ACTION_CONDITION_STATE: &str = "condition_state";
+pub const LOG_ACTION_EVENT_TRIGGER: &str = "event_trigger";
 pub const LOG_ACTION_RUN_COMMAND: &str = "command";
 pub const LOG_ACTION_MAIN_LISTENER: &str = "listener";
 pub const LOG_ACTION_MAIN_START: &str = "starting";

--- a/src/event/base.rs
+++ b/src/event/base.rs
@@ -48,6 +48,11 @@ pub trait Event: Send + Sync {
     /// Must return `true` if the service requires a separate thread.
     fn requires_thread(&self) -> bool;
 
+    /// Must return `false` if the event cannot be manually triggered:
+    /// this is the default, and only manually triggerable events should
+    /// override this function.
+    fn triggerable(&self) -> bool { false }
+
     /// Assign the condition bucket to put verified conditions into.
     fn set_condition_bucket(&mut self, bucket: &'static ExecutionBucket);
 
@@ -113,6 +118,13 @@ pub trait Event: Send + Sync {
                 panic!("execution bucket not set for condition {cond_name}")
             }
         } else {
+            // self.log(
+            //     LogType::Debug,
+            //     LOG_WHEN_PROC,
+            //     LOG_STATUS_FAIL,
+            //     &format!("no condition associated to event"),
+            // );
+            // Ok(false)
             panic!("trying to fire with no condition assigned")
         }
     }

--- a/src/event/dbus_event.rs
+++ b/src/event/dbus_event.rs
@@ -550,7 +550,7 @@ impl DbusMessageEvent {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,

--- a/src/event/fschange_event.rs
+++ b/src/event/fschange_event.rs
@@ -244,7 +244,7 @@ impl FilesystemChangeEvent {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,

--- a/src/event/manual_event.rs
+++ b/src/event/manual_event.rs
@@ -1,0 +1,269 @@
+//! Define an empty event to be manually triggered
+//!
+//! The only way to trigger this type of event is to issue a `trigger`
+//! command on the _stdin_ of a running instance of the scheduler, followed
+//! by the event name. The event has no associated listening service, as the
+//! main program acts as its service instead.
+
+
+use cfgmap::CfgMap;
+
+use super::base::Event;
+use crate::condition::registry::ConditionRegistry;
+use crate::condition::bucket_cond::ExecutionBucket;
+use crate::common::logging::{log, LogType};
+use crate::constants::*;
+
+
+
+/// Manual Command Based Event
+///
+/// Implements an event that is intentionally triggered by issuing a `trigger`
+/// command, followed by the event name, to the _stdin_ of a running instance.
+pub struct ManualCommandEvent {
+    // common members
+    // parameters
+    event_id: i64,
+    event_name: String,
+    condition_name: Option<String>,
+
+    // internal values
+    condition_registry: Option<&'static ConditionRegistry>,
+    condition_bucket: Option<&'static ExecutionBucket>,
+
+    // specific members
+    // parameters
+    // (none here)
+
+    // internal values
+    // (none here)
+}
+
+
+#[allow(dead_code)]
+impl ManualCommandEvent {
+    pub fn new(name: &str) -> Self {
+        log(
+            LogType::Debug,
+            LOG_EMITTER_EVENT_FSCHANGE,
+            LOG_ACTION_NEW,
+            Some((name, 0)),
+            LOG_WHEN_INIT,
+            LOG_STATUS_MSG,
+            &format!("EVENT {name}: creating a new command line triggered event"),
+        );
+        ManualCommandEvent {
+            // reset ID
+            event_id: 0,
+
+            // parameters
+            event_name: String::from(name),
+            condition_name: None,
+
+            // internal values
+            condition_registry: None,
+            condition_bucket: None,
+
+            // specific members initialization
+            // parameters
+
+            // internal values
+        }
+    }
+
+
+
+    /// Load a `CommandLineEvent` from a [`CfgMap`](https://docs.rs/cfgmap/latest/)
+    ///
+    /// The `CommandLineEvent` is initialized according to the values
+    /// provided in the `CfgMap` argument. If the `CfgMap` format does not
+    /// comply with the requirements of a `FilesystemChangeEvent` an error is
+    /// raised.
+    ///
+    /// The TOML configuration file format is the following
+    ///
+    /// ```toml
+    /// # definition (mandatory)
+    /// [[event]]
+    /// name = "FilesystemChangeEventName"
+    /// type = "fschange"
+    /// condition = "AssignedConditionName"
+    ///
+    /// Any incorrect value will cause an error. The value of the `type` entry
+    /// *must* be set to `"fschange"` mandatorily for this type of `Event`.
+    pub fn load_cfgmap(
+        cfgmap: &CfgMap,
+        cond_registry: &'static ConditionRegistry,
+        bucket: &'static ExecutionBucket,
+    ) -> std::io::Result<ManualCommandEvent> {
+
+        fn _invalid_cfg(key: &str, value: &str, message: &str) -> std::io::Result<ManualCommandEvent> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{ERR_INVALID_EVENT_CONFIG}: ({key}={value}) {message}"),
+            ))
+        }
+
+        let check = [
+            "type",
+            "name",
+            "tags",
+            "condition",
+        ];
+        for key in cfgmap.keys() {
+            if !check.contains(&key.as_str()) {
+                return _invalid_cfg(key, STR_UNKNOWN_VALUE,
+                    &format!("{ERR_INVALID_CFG_ENTRY} ({key})"));
+            }
+        }
+
+        // check type
+        let cur_key = "type";
+        let cond_type;
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_str() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_EVENT_TYPE);
+            }
+            cond_type = item.as_str().unwrap().to_owned();
+            if cond_type != "cli" {
+                return _invalid_cfg(cur_key,
+                    &cond_type,
+                    ERR_INVALID_EVENT_TYPE);
+            }
+        } else {
+            return _invalid_cfg(
+                cur_key,
+                STR_UNKNOWN_VALUE,
+                ERR_MISSING_PARAMETER);
+        }
+
+        // common mandatory parameter retrieval
+        let cur_key = "name";
+        let name;
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_str() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_EVENT_NAME);
+            }
+            name = item.as_str().unwrap().to_owned();
+            if !RE_EVENT_NAME.is_match(&name) {
+                return _invalid_cfg(cur_key,
+                    &name,
+                    ERR_INVALID_EVENT_NAME);
+            }
+        } else {
+            return _invalid_cfg(
+                cur_key,
+                STR_UNKNOWN_VALUE,
+                ERR_MISSING_PARAMETER);
+        }
+
+        // initialize the structure
+        // NOTE: the value of "event" for the condition type, which is
+        //       completely functionally equivalent to "bucket", can only
+        //       be set from the configuration file; programmatically built
+        //       conditions of this type will only report "bucket" as their
+        //       type, and "event" is only left for configuration readability
+        let mut new_event = ManualCommandEvent::new(
+            &name,
+        );
+        new_event.condition_registry = Some(cond_registry);
+        new_event.condition_bucket = Some(bucket);
+
+        // common optional parameter initialization
+        let cur_key = "tags";
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_list() && !item.is_map() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_PARAMETER);
+            }
+        }
+
+        let cur_key = "condition";
+        let condition;
+        if let Some(item) = cfgmap.get(cur_key) {
+            if !item.is_str() {
+                return _invalid_cfg(
+                    cur_key,
+                    STR_UNKNOWN_VALUE,
+                    ERR_INVALID_EVENT_NAME);
+            }
+            condition = item.as_str().unwrap().to_owned();
+            if !RE_COND_NAME.is_match(&condition) {
+                return _invalid_cfg(cur_key,
+                    &condition,
+                    ERR_INVALID_COND_NAME);
+            }
+        } else {
+            return _invalid_cfg(
+                cur_key,
+                STR_UNKNOWN_VALUE,
+                ERR_MISSING_PARAMETER);
+        }
+        if !new_event.condition_registry.unwrap().has_condition(&condition) {
+            return _invalid_cfg(
+                cur_key,
+                &condition,
+                ERR_INVALID_EVENT_CONDITION);
+        }
+        new_event.assign_condition(&condition)?;
+
+        // common optional parameter initialization
+        // (none here)
+
+        Ok(new_event)
+    }
+
+}
+
+
+impl Event for ManualCommandEvent {
+
+    fn set_id(&mut self, id: i64) { self.event_id = id; }
+    fn get_name(&self) -> String { self.event_name.clone() }
+    fn get_id(&self) -> i64 { self.event_id }
+
+    fn requires_thread(&self) -> bool { true }  // maybe false, let's see
+
+    fn triggerable(&self) -> bool { true }      // this is the only one
+
+    fn get_condition(&self) -> Option<String> { self.condition_name.clone() }
+
+    fn set_condition_registry(&mut self, reg: &'static ConditionRegistry) {
+        self.condition_registry = Some(reg);
+    }
+
+    fn condition_registry(&self) -> Option<&'static ConditionRegistry> {
+        self.condition_registry
+    }
+
+    fn set_condition_bucket(&mut self, bucket: &'static ExecutionBucket) {
+        self.condition_bucket = Some(bucket);
+    }
+
+    fn condition_bucket(&self) -> Option<&'static ExecutionBucket> {
+        self.condition_bucket
+    }
+
+    fn _assign_condition(&mut self, cond_name: &str) {
+        // correctness has already been checked by the caller
+        self.condition_name = Some(String::from(cond_name));
+    }
+
+
+    fn _start_service(&self) -> std::io::Result<bool> {
+        // in this case the service exits immediately without errors
+        Ok(true)
+    }
+
+}
+
+
+// end.

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -6,5 +6,6 @@ pub mod registry;   // the main event registry
 // specific event types
 pub mod fschange_event;
 pub mod dbus_event;
+pub mod manual_event;
 
 // end.

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,12 +78,6 @@ lazy_static! {
 }
 
 
-// default values
-const DEFAULT_SCHEDULER_TICK_SECONDS: i64 = 5;
-const DEFAULT_RANDOMIZE_CHECKS_WITHIN_TICKS: bool = false;
-
-
-
 // check whether an instance is already running, and return an error if so
 fn check_single_instance(instance: &SingleInstance) -> std::io::Result<()> {
     if !instance.is_single() {
@@ -865,9 +859,10 @@ fn trigger_event(name: &str) -> std::io::Result<bool> {
 // from the standard input, therefore no explicit synchronization
 fn interpret_commands() -> std::io::Result<bool> {
     let mut buffer = String::new();
-    let rest_time = Duration::from_millis(DEFAULT_SCHEDULER_TICK_SECONDS as u64 * 100);
+    let rest_time = Duration::from_millis(MAIN_STDIN_READ_WAIT_MILLISECONDS);
 
     while let Ok(_n) = stdin().read_line(&mut buffer) {
+        // note that `split_whitespace()` already trims its argument
         let v: Vec<&str> = buffer.split_whitespace().collect();
         if v.len() > 0 {
             let cmd = v[0];
@@ -1161,6 +1156,8 @@ fn interpret_commands() -> std::io::Result<bool> {
                     );
                 }
             }
+
+            // clear the buffer immediately after consuming the line
             buffer.clear();
         }
         thread::sleep(rest_time);

--- a/src/task/command_task.rs
+++ b/src/task/command_task.rs
@@ -498,7 +498,7 @@ impl CommandTask {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,

--- a/src/task/lua_task.rs
+++ b/src/task/lua_task.rs
@@ -291,7 +291,7 @@ impl LuaTask {
         // common optional parameter initialization
         let cur_key = "tags";
         if let Some(item) = cfgmap.get(cur_key) {
-            if !item.is_list() {
+            if !item.is_list() && !item.is_map() {
                 return _invalid_cfg(
                     cur_key,
                     STR_UNKNOWN_VALUE,


### PR DESCRIPTION
Accept tables as values for the `tags` configuration entry for items closing #23, and implement the `trigger` command to raise specific events (of `"cli"` type) and therefore fire event based conditions closing #24.