### PR TITLE
Optional features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,14 @@ name = "whenever"
 description = "Lightweight task scheduler and automation tool"
 readme = "README.md"
 license = "LGPL-2.1-or-later"
-version = "0.2.15"
+version = "0.2.16"
 authors = ["Francesco Garosi <francesco.garosi@gmail.com>"]
 repository = "https://github.com/almostearthling/whenever/"
 edition = "2024"
+
+[features]
+default = ["dbus"]
+dbus = []
 
 [dependencies]
 time = "0.3.17"

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@
       - [Idle session](#idle-session)
       - [Command](#command)
       - [Lua script](#lua-script)
-      - [DBus method](#dbus-method)
+      - [DBus method (optional)](#dbus-method-optional)
       - [Event based](#event-based)
     - [Events](#events)
       - [Filesystem changes](#filesystem-changes)
-      - [DBus signals](#dbus-signals)
+      - [DBus signals (optional)](#dbus-signals-optional)
       - [Command line](#command-line)
   - [Logging](#logging)
   - [Input commands](#input-commands)
@@ -71,16 +71,16 @@ The supported types of [**_condition_**](#conditions) are the following:
 * [_Idle_ user session](#command): this type of condition is verified after the session has been idle for the specified amount of time
 * [_Command_ execution](#command): an available executable (be it a script, a batch file on Windows, a binary) is run, its exit code or output is checked and, when an expected outcome is found, the condition is considered verified - or failed on an explicitly undesired outcome
 * [_Lua_ script execution](#lua-script): a _Lua_ script is run using the embedded interpreter, and if the contents of one or more variables meet the specified expectations the condition is considered verified
-* [_DBus_ inspection](#dbus-method): a _DBus_ method is executed and the result is checked against some criteria provided in the configuration file
+* [_DBus_ inspection (optional)](#dbus-method-optional): a _DBus_ method is executed and the result is checked against some criteria provided in the configuration file
 * [_Event_ based](#event-based): are verified when a certain event occurs that fires the condition.
 
 The [**_events_**](#events) that can fire _event_ based conditions are, at the moment:
 
 * [_Filesystem changes_](#filesystem-changes), that is, changes in files and/or directories that are set to be monitored
-* [_DBus signals_](#dbus-signals), that may be filtered for an expected payload
+* [_DBus_ signals (optional)](#dbus-signals-optional), that may be filtered for an expected payload
 * [_Command line_](#command-line), that are manually triggered by writing to **whenever** standard input.
 
-Note that _DBus_ events and conditions are also (theoretically) supported on Windows, being one of the _DBus_ target platforms.
+Note that _DBus_ events and conditions are also supported on Windows, being one of the _DBus_ target platforms, and enabled by default. However _DBus_ support can be **disabled** on build, by removing it as a default feature in the _Cargo.toml_ file or by building with the `--no-default-features` command line flag (in this case, other desirable features have to be enabled specifically using the `--features` option).
 
 All of the above listed items are fully configurable via a TOML configuration file, that _must_ be specified as the only mandatory argument on the command line. The syntax of the configuration file is described in the following sections.
 
@@ -582,7 +582,7 @@ The `recur_after_failed_check` flag allows for avoidance of multiple subsequent 
 
 For this type of condition the actual test can be performed at a random time within the tick interval.
 
-#### DBus method
+#### DBus method (optional)
 
 The return message of a _DBus method invocation_ is used to determine the execution of the tasks associated to this type of condition. Due to the nature of DBus, the configuration of a _DBus_ based condition is quite complex, both in terms of definition of the method to be invoked, especially for what concerns the parameters to be passed to the method, and in terms of specifying how to test the result.[^8] One of the most notable difficulties consists in the necessity to use embedded _JSON_[^2] in the TOML configuration file: this choice arose due to the fact that, to specify the arguments to pass to the invoked methods and the criteria used to determine the invocation success, _non-homogeneous_ lists are needed -- which are not supported, intentionally, by TOML.
 
@@ -775,11 +775,11 @@ The configuration entries are:
 | `recursive`        | _false_ | if _true_, listed directories will be monitored recursively                                |
 | `poll_seconds`     | 2       | generally not used, can be needed on systems where the notification service is unavailable |
 
-#### DBus signals
+#### DBus signals (optional)
 
 DBus provides signals that can be subscribed by applications, to receive information about various aspects of the system status in an asynchronous way. **whenever** offers the possibility to subscribe to these signals, so that when the _return parameters_ match the provided constraints, then the event occurs and the associated condition is fired.
 
-Subscription is performed by providing a _watch expression_ in the same form that is used by the [_dbus-monitor_](https://dbus.freedesktop.org/doc/dbus-monitor.1.html) utility, therefore JSON is not used for this purpose. JSON is used instead to specify the criteria that the _signal parameters_ must meet in order for the event to arise, using the same format that is used for _return message parameter_ checks in [_DBus method_ based conditions](#dbus-method).
+Subscription is performed by providing a _watch expression_ in the same form that is used by the [_dbus-monitor_](https://dbus.freedesktop.org/doc/dbus-monitor.1.html) utility, therefore JSON is not used for this purpose. JSON is used instead to specify the criteria that the _signal parameters_ must meet in order for the event to arise, using the same format that is used for _return message parameter_ checks in [_DBus method_ based conditions](#dbus-method-optional).
 
 A sample configuration section follows:
 
@@ -820,7 +820,7 @@ and the details of the configuration entries are described in the table below:
 | `parameter_check_all` | _false_ | if _true_, all the returned parameters will have to match the criteria for verification, otherwise one match is sufficient  |
 | `parameter_check`     | (empty) | a list of maps consisting of three fields each, each of which is a check to be performed on return parameters               |
 
-The considerations about indexes in return parameters are the same that have been seen for [_DBus message_ based conditions](#dbus-method). It is worth to remind that any errors that may arise during checks will cause the check itself to yield _false_.
+The considerations about indexes in return parameters are the same that have been seen for [_DBus message_ based conditions](#dbus-method-optional). It is worth to remind that any errors that may arise during checks will cause the check itself to yield _false_.
 
 If no parameter checks are provided, the event arises simply when the signal is caught.
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1321,6 +1321,7 @@ pub mod luaitem {
     }
 }
 
+#[cfg(feature = "dbus")]
 #[allow(dead_code)]
 pub mod dbusitem {
     use crate::constants::*;

--- a/src/condition/dbus_cond.rs
+++ b/src/condition/dbus_cond.rs
@@ -5,6 +5,9 @@
 //! configuration. The difference with the event based process consists in
 //! the condition actively requesting DBus for a result.
 
+// this is only available when the "dbus" feature is enabled
+#![cfg(feature = "dbus")]
+
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::{Duration, Instant};
 

--- a/src/condition/mod.rs
+++ b/src/condition/mod.rs
@@ -6,10 +6,12 @@ pub mod registry; // the main condition registry
 // specific condition types
 pub mod bucket_cond;
 pub mod command_cond;
-pub mod dbus_cond;
 pub mod idle_cond;
 pub mod interval_cond;
 pub mod lua_cond;
 pub mod time_cond;
+
+#[cfg(feature = "dbus")]
+pub mod dbus_cond;
 
 // end.

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,7 @@ pub fn check_configuration(config_file: &str) -> Result<()> {
                                 &task_list,
                             )?;
                         }
+                        #[cfg(feature = "dbus")]
                         "dbus" => {
                             name = condition::dbus_cond::DbusMethodCondition::check_cfgmap(
                                 entry.as_map().unwrap(),
@@ -164,6 +165,7 @@ pub fn check_configuration(config_file: &str) -> Result<()> {
                                 &condition_list,
                             )?;
                         }
+                        #[cfg(feature = "dbus")]
                         "dbus" => {
                             name = event::dbus_event::DbusMessageEvent::check_cfgmap(
                                 entry.as_map().unwrap(),
@@ -545,6 +547,7 @@ fn configure_conditions(
                                 return Err(Error::new(Kind::Invalid, ERR_CONDREG_COND_NOT_ADDED));
                             }
                         }
+                        #[cfg(feature = "dbus")]
                         "dbus" => {
                             let condition = condition::dbus_cond::DbusMethodCondition::load_cfgmap(
                                 entry.as_map().unwrap(),
@@ -832,6 +835,7 @@ fn reconfigure_conditions(
                                 );
                             }
                         }
+                        #[cfg(feature = "dbus")]
                         "dbus" => {
                             let condition = condition::dbus_cond::DbusMethodCondition::load_cfgmap(
                                 entry.as_map().unwrap(),
@@ -1002,6 +1006,7 @@ fn configure_events(
                                 ));
                             }
                         }
+                        #[cfg(feature = "dbus")]
                         "dbus" => {
                             let event = event::dbus_event::DbusMessageEvent::load_cfgmap(
                                 entry.as_map().unwrap(),
@@ -1176,6 +1181,7 @@ fn reconfigure_events(
                                 );
                             }
                         }
+                        #[cfg(feature = "dbus")]
                         "dbus" => {
                             let event = event::dbus_event::DbusMessageEvent::load_cfgmap(
                                 entry.as_map().unwrap(),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -114,15 +114,19 @@ pub const LOG_EMITTER_MAIN: &str = "MAIN";
 
 pub const LOG_EMITTER_TASK_COMMAND: &str = "COMMAND_TASK";
 pub const LOG_EMITTER_TASK_LUA: &str = "LUA_TASK";
-pub const LOG_EMITTER_EVENT_DBUS: &str = "DBUS_EVENT";
+
 pub const LOG_EMITTER_EVENT_FSCHANGE: &str = "FSCHANGE_EVENT";
 pub const LOG_EMITTER_EVENT_MANUAL: &str = "CMD_EVENT";
+#[cfg(feature = "dbus")]
+pub const LOG_EMITTER_EVENT_DBUS: &str = "DBUS_EVENT";
+
 pub const LOG_EMITTER_CONDITION_INTERVAL: &str = "INTERVAL_CONDITION";
 pub const LOG_EMITTER_CONDITION_BUCKET: &str = "BUCKET_CONDITION";
 pub const LOG_EMITTER_CONDITION_COMMAND: &str = "COMMAND_CONDITION";
-pub const LOG_EMITTER_CONDITION_DBUS: &str = "DBUS_CONDITION";
 pub const LOG_EMITTER_CONDITION_IDLE: &str = "IDLE_CONDITION";
 pub const LOG_EMITTER_CONDITION_LUA: &str = "LUA_CONDITION";
+#[cfg(feature = "dbus")]
+pub const LOG_EMITTER_CONDITION_DBUS: &str = "DBUS_CONDITION";
 
 pub const LOG_ACTION_NEW: &str = "new";
 pub const LOG_ACTION_TICK: &str = "tick";
@@ -173,6 +177,13 @@ lazy_static! {
     pub static ref LUAVAR_NAME_TASK: String = format!("{}_task", APP_NAME.to_ascii_lowercase());
     pub static ref LUAVAR_NAME_COND: String = format!("{}_condition", APP_NAME.to_ascii_lowercase());
 
+    // interval for polling spawned commands for stdout/stderr contents
+    pub static ref DUR_SPAWNED_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+}
+
+#[cfg(feature = "dbus")]
+lazy_static! {
     // DBus names regular expressions (see https://dbus.freedesktop.org/doc/dbus-specification.html)
     // Note that bus names adhere to specification as in (quoting): "only
     // elements that are part of a unique connection name may begin with a
@@ -189,10 +200,6 @@ lazy_static! {
     pub static ref RE_DBUS_INTERFACE_NAME: Regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$").unwrap();
     pub static ref RE_DBUS_MEMBER_NAME: Regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
     pub static ref RE_DBUS_ERROR_NAME: Regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$").unwrap();
-
-    // interval for polling spawned commands for stdout/stderr contents
-    pub static ref DUR_SPAWNED_POLL_INTERVAL: Duration = Duration::from_millis(100);
-
 }
 
 // end.

--- a/src/event/dbus_event.rs
+++ b/src/event/dbus_event.rs
@@ -4,6 +4,9 @@
 //! to expect from that channel. The event listens on a new thread and pushes
 //! the related condition in the execution bucket when all constraints are met.
 
+// this is only available when the "dbus" feature is enabled
+#![cfg(feature = "dbus")]
+
 use regex::Regex;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{mpsc, Arc, RwLock};

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -4,8 +4,10 @@ pub mod base; // this only defines the trait
 pub mod registry; // the main event registry
 
 // specific event types
-pub mod dbus_event;
 pub mod fschange_event;
 pub mod manual_event;
+
+#[cfg(feature = "dbus")]
+pub mod dbus_event;
 
 // end.


### PR DESCRIPTION
Start considering conditional compilation for parts that are not supported/not needed on some platforms, and give the possibility to opt out. The first feature that becomes optional is _DBus_ support, which is available (maybe not for a long time, though) on Windows, but there are not many options nor reasons to use it: removal of _DBus_ support on Windows significantly reduces the executable file size -- although it has no such impact on the memory footprint when running.

Fixes #58.